### PR TITLE
Add support for share URL from mobile client

### DIFF
--- a/src/tg.js
+++ b/src/tg.js
@@ -240,9 +240,9 @@ function extract_fid (text) {
     if (!text.startsWith('http')) text = 'https://' + text
     const u = new URL(text)
     if (u.pathname.includes('/folders/')) {
-      const reg = /\/folders\/([a-zA-Z0-9_-]{10,100})/
+      const reg = /(?<=\/)[^\/?]+(?=(\?|$))/
       const match = u.pathname.match(reg)
-      return match && match[1]
+      return match && match[0]
     }
     return u.searchParams.get('id')
   } catch (e) {

--- a/src/tg.js
+++ b/src/tg.js
@@ -240,7 +240,7 @@ function extract_fid (text) {
     if (!text.startsWith('http')) text = 'https://' + text
     const u = new URL(text)
     if (u.pathname.includes('/folders/')) {
-      const reg = /(?<=\/)[^\/?]+(?=(\?|$))/
+      const reg = /[^\/?]+$/
       const match = u.pathname.match(reg)
       return match && match[0]
     }


### PR DESCRIPTION
Support both share URL formats like `https://drive.google.com/drive/folders/{folderId}` and
`https://drive.google.com/drive/u/0/mobile/folders/{???}/{folderId}?usp=sharing&sort=13&direction=a`