### PR TITLE
Ensure extract_from_text method stops at white-space characters

### DIFF
--- a/src/tg.js
+++ b/src/tg.js
@@ -251,7 +251,7 @@ function extract_fid (text) {
 }
 
 function extract_from_text (text) {
-  const reg = /https?:\/\/drive.google.com\/.+/g
+  const reg = /https?:\/\/drive.google.com\/[^\s]+/g
   const m = text.match(reg)
   return m && extract_fid(m[0])
 }


### PR DESCRIPTION
Fix failed to extract URL for messages with extra text after the URL, such as `https://drive.google.com/drive/folders/{folderId} #GoogleDrive `